### PR TITLE
Implemented method to prevent rotation of mapland maps in itemframes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.bergerkiller.bukkit</groupId>
   <artifactId>Maplands</artifactId>
-  <version>0.5</version>
+  <version>0.6</version>
   <packaging>jar</packaging>
 
   <name>Maplands</name>

--- a/src/main/java/com/bergerkiller/bukkit/maplands/IsometricBlockSprites.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/IsometricBlockSprites.java
@@ -23,9 +23,9 @@ public class IsometricBlockSprites {
     private final BlockFace facing;
     private final ZoomLevel zoom;
     private final Matrix4f transform;
-    public final int width;
-    public final int height;
-    public final MapTexture AIR;
+    private final int width;
+    private final int height;
+    final MapTexture AIR;
 
     private IsometricBlockSprites(BlockFace facing, ZoomLevel zoom) {
         this.facing = facing;
@@ -41,7 +41,7 @@ public class IsometricBlockSprites {
      * 
      * @return zoom level
      */
-    public ZoomLevel getZoom() {
+    ZoomLevel getZoom() {
         return this.zoom;
     }
 
@@ -50,15 +50,15 @@ public class IsometricBlockSprites {
      * 
      * @return sprite brush
      */
-    public MapTexture getBrushTexture() {
+    MapTexture getBrushTexture() {
         return this.zoom.getMask();
     }
 
-    public MapTexture getSprite(Material material) {
+    MapTexture getSprite(Material material) {
         return getSprite(BlockData.fromMaterial(material).getDefaultRenderOptions());
     }
 
-    public MapTexture getSprite(BlockRenderOptions options) {
+    private MapTexture getSprite(BlockRenderOptions options) {
         MapTexture result = spriteCache.get(options);
         if (result == null) {
             result = MapTexture.createEmpty(this.width, this.height);
@@ -82,7 +82,7 @@ public class IsometricBlockSprites {
         return getSprite(block.getWorld(), block.getX(), block.getY(), block.getZ());
     }
 
-    public MapTexture getSprite(World world, int x, int y, int z) {
+    MapTexture getSprite(World world, int x, int y, int z) {
         return getSprite(BlockRenderOptions.fromBlock(world, x, y, z));
     }
 
@@ -90,7 +90,7 @@ public class IsometricBlockSprites {
 
     private static List<IsometricBlockSprites> instances = new ArrayList<IsometricBlockSprites>();
 
-    public static IsometricBlockSprites getSprites(BlockFace facing, ZoomLevel zoom) {
+    static IsometricBlockSprites getSprites(BlockFace facing, ZoomLevel zoom) {
         for (IsometricBlockSprites sprites : instances) {
             if (sprites.facing == facing && sprites.zoom == zoom) {
                 return sprites;

--- a/src/main/java/com/bergerkiller/bukkit/maplands/MapUtil.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/MapUtil.java
@@ -1,17 +1,27 @@
 package com.bergerkiller.bukkit.maplands;
 
+import com.bergerkiller.bukkit.common.map.MapDisplay;
+import com.bergerkiller.bukkit.common.nbt.CommonTagCompound;
+import com.bergerkiller.bukkit.common.utils.ItemUtil;
+import com.bergerkiller.generated.net.minecraft.server.EntityItemFrameHandle;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 
 import com.bergerkiller.bukkit.common.bases.IntVector3;
 import com.bergerkiller.bukkit.common.utils.MathUtil;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.inventory.ItemStack;
 
 public class MapUtil {
     /**
      * Checks whether a particular set of tile coordinates if a valid tile
      * 
-     * @param tx
-     * @param ty
-     * @param tz
+     * @param tx The tiles X coordinate.
+     * @param ty The tiles Y coordinate.
+     * @param tz The tiles Z coordinate.
+     *
      * @return True if the coordinates represent a valid tile
      */
     public static boolean isTile(int tx, int ty, int tz) {
@@ -33,6 +43,7 @@ public class MapUtil {
      * 
      * @param facing view
      * @param p tile coordinates
+     *
      * @return block coordinates. Null if not a valid tile.
      */
     public static IntVector3 screenTileToBlock(BlockFace facing, IntVector3 p) {
@@ -46,6 +57,7 @@ public class MapUtil {
      * @param px tile coordinates x
      * @param py tile coordinates y
      * @param pz tile coordinates z
+     *
      * @return block coordinates. Null if not a valid tile.
      */
     public static IntVector3 screenTileToBlock(BlockFace facing, int px, int py, int pz) {
@@ -83,6 +95,7 @@ public class MapUtil {
      * 
      * @param facing view
      * @param blockPos relative block coordinates
+     *
      * @return output tile coordinates
      */
     public static IntVector3 blockToScreenTile(BlockFace facing, IntVector3 blockPos) {
@@ -96,13 +109,12 @@ public class MapUtil {
      * @param dx relative block coordinate x
      * @param dy relative block coordinate y
      * @param dz relative block coordinate z
+     *
      * @return tile coordinates
      */
     public static IntVector3 blockToScreenTile(BlockFace facing, int dx, int dy, int dz) {
         // Undo facing
-        if (facing == BlockFace.NORTH_EAST) {
-            // nothing
-        } else if (facing == BlockFace.SOUTH_WEST) {
+        if (facing == BlockFace.SOUTH_WEST) {
             dx = -dx;
             dz = -dz;
         } else if (facing == BlockFace.NORTH_WEST) {
@@ -146,5 +158,18 @@ public class MapUtil {
             }
         }
         return new IntVector3(px, py, pz);
+    }
+
+    static boolean isMaplandMap(Entity entity){
+        if(!(entity instanceof ItemFrame)) return false;
+
+        ItemFrame itemFrame = (ItemFrame)entity;
+        ItemStack itemStack = itemFrame.getItem();
+        if(!itemStack.getType().equals(Material.MAP)) return false;
+
+        CommonTagCompound tags = ItemUtil.getMetaTag(EntityItemFrameHandle.fromBukkit(itemFrame).getItem());
+        if(tags == null) return false;
+
+        return tags.containsKey("mapDisplayClass");
     }
 }

--- a/src/main/java/com/bergerkiller/bukkit/maplands/Maplands.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/Maplands.java
@@ -9,12 +9,13 @@ import com.bergerkiller.bukkit.common.PluginBase;
 import com.bergerkiller.bukkit.common.config.FileConfiguration;
 import com.bergerkiller.bukkit.common.map.MapDisplay;
 import com.bergerkiller.bukkit.common.map.MapResourcePack;
+import org.bukkit.material.MaterialData;
 
 public class Maplands extends PluginBase {
-    public static Maplands plugin;
+    private static Maplands plugin;
     private static MapResourcePack resourcePack;
 
-    public static MapResourcePack getResourcePack() {
+    static MapResourcePack getResourcePack() {
         if (resourcePack == null) {
             resourcePack = MapResourcePack.VANILLA; // fallback under test
             MapResourcePack.VANILLA.load(); // test! Make sure it is loaded.

--- a/src/main/java/com/bergerkiller/bukkit/maplands/MaplandsListener.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/MaplandsListener.java
@@ -1,15 +1,20 @@
 package com.bergerkiller.bukkit.maplands;
 
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.bergerkiller.bukkit.common.map.MapDisplay;
 import com.bergerkiller.bukkit.common.utils.FaceUtil;
+import org.bukkit.inventory.ItemStack;
 
 public class MaplandsListener implements Listener {
 
@@ -41,5 +46,12 @@ public class MaplandsListener implements Listener {
         if (event.getClickedBlock() != null) {
             handleBlockChanges(event.getClickedBlock());
         }
+    }
+
+    @EventHandler
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event){
+        if(!MapUtil.isMaplandMap(event.getRightClicked())) return;
+
+        event.setCancelled(true);
     }
 }

--- a/src/main/java/com/bergerkiller/bukkit/maplands/MenuButton.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/MenuButton.java
@@ -14,7 +14,7 @@ public class MenuButton {
     private int blinkCtr;
     private MapDisplay display;
 
-    public MenuButton(String textureName, int x, int y) {
+    MenuButton(String textureName, int x, int y) {
         this.x = x;
         this.y = y;
         this.selected = false;
@@ -30,11 +30,11 @@ public class MenuButton {
         this.texture_off.draw(texture_base, 0, 0, MapColorPalette.COLOR_BLACK);
     }
 
-    public void setDisplay(MapDisplay display) {
+    void setDisplay(MapDisplay display) {
         this.display = display;
     }
 
-    public void onTick() {
+    void onTick() {
         if (this.changed) {
             this.changed = false;
             if (this.visible) {
@@ -62,7 +62,7 @@ public class MenuButton {
     public void onPressed() {
     }
 
-    public void setVisible(boolean visible) {
+    void setVisible(boolean visible) {
         if (this.visible != visible) {
             this.visible = visible;
             this.changed = true;
@@ -70,7 +70,7 @@ public class MenuButton {
         }
     }
 
-    public void setSelected(boolean selected) {
+    void setSelected(boolean selected) {
         if (this.selected != selected) {
             this.selected = selected;
             this.changed = true;

--- a/src/main/java/com/bergerkiller/bukkit/maplands/TestFrameMap.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/TestFrameMap.java
@@ -40,7 +40,7 @@ public class TestFrameMap extends MapDisplay {
     private final HashSet<IntVector3> dirtyTiles = new HashSet<IntVector3>();
     private MenuButton[] menuButtons;
     private MapTexture menu_bg;
-    int rendertime = 0;
+    private int rendertime = 0;
     private static final int MENU_DURATION = 200; // amount of ticks menu is kept open while idle
 
     @Override
@@ -144,7 +144,7 @@ public class TestFrameMap extends MapDisplay {
         rendertime = 0;
     }
 
-    public void onBlockChange(Block block) {
+    void onBlockChange(Block block) {
         int dx = block.getX() - this.startBlock.getX();
         int dy = block.getY() - this.startBlock.getY();
         int dz = block.getZ() - this.startBlock.getZ();
@@ -213,7 +213,7 @@ public class TestFrameMap extends MapDisplay {
         }
     }
 
-    public void moveTiles(int dtx, int dtz, BlockFace blockChange) {
+    private void moveTiles(int dtx, int dtz, BlockFace blockChange) {
         // Move all pixels
         getLayer().movePixels(
                 zoom.getScreenX(dtx) - zoom.getScreenX(0),
@@ -270,7 +270,7 @@ public class TestFrameMap extends MapDisplay {
         render(false);
     }
 
-    public boolean drawBlock(int x, int y, int z, boolean isRedraw) {
+    private boolean drawBlock(int x, int y, int z, boolean isRedraw) {
         IntVector3 b = getBlockAtTile(x, y, z);
         if (b != null) {
             int draw_x = sprites.getZoom().getDrawX(x);
@@ -286,8 +286,8 @@ public class TestFrameMap extends MapDisplay {
     private int getLight(int x, int y, int z) {
         return WorldUtil.getSkyLight(this.startBlock.getWorld().getChunkAt(x >> 4, z >> 4), x, y, z);
     }
-    
-    public boolean drawBlock(IntVector3 d, int draw_x, int draw_y, boolean isRedraw) {
+
+    private boolean drawBlock(IntVector3 d, int draw_x, int draw_y, boolean isRedraw) {
         int x = this.startBlock.getX() + d.x;
         int y = this.startBlock.getY() + d.y;
         int z = this.startBlock.getZ() + d.z;
@@ -329,7 +329,7 @@ public class TestFrameMap extends MapDisplay {
         }
     }
 
-    public void hideMenu() {
+    private void hideMenu() {
         menuShowTicks = 0;
         for (MenuButton button : this.menuButtons) {
             button.setVisible(false);
@@ -337,7 +337,7 @@ public class TestFrameMap extends MapDisplay {
         getLayer(1).clearRectangle(0, 0, this.menu_bg.getWidth(), this.menu_bg.getHeight());
     }
 
-    public void showMenu() {
+    private void showMenu() {
         menuShowTicks = MENU_DURATION;
         for (int i = 0; i < this.menuButtons.length; i++) {
             this.menuButtons[i].setVisible(true);
@@ -346,7 +346,7 @@ public class TestFrameMap extends MapDisplay {
         getLayer(1).draw(this.menu_bg, 0, 0);
     }
 
-    public void setMenuIndex(int index) {
+    private void setMenuIndex(int index) {
         while (index < 0) {
             index += this.menuButtons.length;
         }

--- a/src/main/java/com/bergerkiller/bukkit/maplands/ZoomLevel.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/ZoomLevel.java
@@ -73,6 +73,7 @@ public enum ZoomLevel {
      * Gets the x-position of the middle of a certain tile as drawn on the screen
      * 
      * @param tx - coordinate of the tile
+     *
      * @return x screen position of the tile (middle)
      */
     public final int getScreenX(int tx) {
@@ -83,6 +84,7 @@ public enum ZoomLevel {
      * Gets the z-position of the middle of a certain tile as drawn on the screen
      * 
      * @param tz - coordinate of the tile
+     *
      * @return z screen position of the tile (middle)
      */
     public final int getScreenZ(int tz) {
@@ -93,6 +95,7 @@ public enum ZoomLevel {
      * Gets the x-position of a certain sprite coordinate as drawn on the canvas
      * 
      * @param x - coordinate of the sprite
+     *
      * @return x - position on the canvas (top-left)
      */
     public final int getDrawX(int x) {
@@ -103,6 +106,7 @@ public enum ZoomLevel {
      * Gets the z-position of a certain sprite coordinate as drawn on the canvas
      * 
      * @param z - coordinate of the sprite
+     *
      * @return z - position on the canvas (top-left)
      */
     public final int getDrawZ(int z) {
@@ -113,6 +117,7 @@ public enum ZoomLevel {
      * Takes a coordinate of a tile and returns the coordinate in the middle of the tile on the screen.
      * 
      * @param p coordinate of the tile (y is depth)
+     *
      * @return screen coordinate of the middle of the tile
      */
     public final IntVector3 tileToScreen(IntVector3 p) {
@@ -124,6 +129,7 @@ public enum ZoomLevel {
      * This function is incredibly slow right now and really needs optimization!
      * 
      * @param p coordinate on the screen (y is depth)
+     *
      * @return tile coordinate at this screen coordinate
      */
     public final IntVector3 screenToTile(IntVector3 p) {
@@ -135,9 +141,10 @@ public enum ZoomLevel {
             int foundTileX_X = 0;
             int foundTileZ_X = 0;
             int lastDistSqZ = Integer.MAX_VALUE;
-            boolean foundAny = false;
+            boolean foundAny;
             for (int tz = 0;;tz++) {
                 if (!MapUtil.isTile(tx, p.y, tz)) {
+                    foundAny = false;
                     continue;
                 }
                 foundAny = true;

--- a/src/main/java/com/bergerkiller/bukkit/maplands/ZoomLevel.java
+++ b/src/main/java/com/bergerkiller/bukkit/maplands/ZoomLevel.java
@@ -141,10 +141,9 @@ public enum ZoomLevel {
             int foundTileX_X = 0;
             int foundTileZ_X = 0;
             int lastDistSqZ = Integer.MAX_VALUE;
-            boolean foundAny;
+            boolean foundAny = false;
             for (int tz = 0;;tz++) {
                 if (!MapUtil.isTile(tx, p.y, tz)) {
-                    foundAny = false;
                     continue;
                 }
                 foundAny = true;


### PR DESCRIPTION
### Changes
- Added method to prevent players from rotating (rightclicking) a item frame, that contains a map from mapland. (Closes #13 and closes #14) 
- Made some methods and classes package-private or private because
  1. IntelliJ complained about that and
  2. It still works from my tests... (No guarantee tho)
- Added missing comments on javadoc description of a method.